### PR TITLE
feat: 添加vnstat作为Linux必需依赖

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -180,7 +180,7 @@ uninstall_previous
 install_dependencies() {
     log_step "Checking and installing dependencies..."
 
-    local deps="curl"
+    local deps="curl vnstat"
     local missing_deps=""
     for cmd in $deps; do
         if ! command -v $cmd >/dev/null 2>&1; then


### PR DESCRIPTION
- 在install.sh脚本中将vnstat添加到依赖列表
- vnstat用于网络流量监控，为komari-agent提供网络统计功能
- 脚本会自动根据系统包管理器(apt/yum/apk/brew)安装vnstat

🤖 Generated with [Claude Code](https://claude.ai/code)