### PR TITLE
fix: 修复安装脚本中 macOS 的参数处理

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -625,9 +625,7 @@ EOF
     
     # Add program arguments if provided
     if [ -n "$komari_args" ]; then
-        for arg in $komari_args; do
-            echo "        <string>$arg</string>" >> "$plist_file"
-        done
+        echo "$komari_args" | xargs -n1 printf "        <string>%s</string>\n"  
     fi
     
     cat >> "$plist_file" << EOF


### PR DESCRIPTION
之前的方式会导致 plist 中的参数为：

```xml
    <array>
        <string>/Users/username/.komari/agent</string>
        <string>-e https://komari.example.com -t token</string>
    </array>
```

这会导致运行失败，日志如下：

```
2025/10/26 19:16:58 Failed to connect to WebSocket: parse "ws https://komari.example.com -t token/api/clients/report?token=": first path segment in URL cannot contain colon
2025/10/26 19:17:03 Max retries reached.
2025/10/26 19:17:05 Error uploading basic info: parse " https://komari.example.com -t token/api/clients/report?token=": first path segment in URL cannot contain colon
```

修改之后可以正常运行。

```xml
    <array>
        <string>/Users/username/.komari/agent</string>
        <string>-e</string>
        <string>https://komari.example.com</string>
        <string>-t</string>
        <string>token</string>
    </array>
```