### PR TITLE
fix: Correct disk size calculation: ZFS dedup + AutoFS trigger exclusion

### DIFF
--- a/monitoring/unit/disk.go
+++ b/monitoring/unit/disk.go
@@ -14,6 +14,7 @@ type DiskInfo struct {
 
 func Disk() DiskInfo {
 	diskinfo := DiskInfo{}
+	// 获取所有分区，使用 true 避免物理磁盘被 gopsutil 错误排除
 	usage, err := disk.Partitions(true)
 	if err != nil {
 		diskinfo.Total = 0
@@ -107,7 +108,8 @@ func isPhysicalDisk(part disk.PartitionStat) bool {
 	}
 
 	fstype := strings.ToLower(part.Fstype)
-	// // 针对 Linux autofs：它只是自动挂载的触发器，真实文件系统会作为单独分区出现。
+
+	// 针对 Linux autofs：排除自动挂载的 trigger，真实文件系统会作为单独分区出现不会被排除。
 	// 将 autofs 视为“非物理磁盘”可以避免重复统计容量。
 	if fstype == "autofs" && !strings.HasPrefix(part.Device, "/dev/") {
 		return false


### PR DESCRIPTION
⸻

### Keep disk.Partitions(true) (after review decision)

### 保留 disk.Partitions(true)（根据 Review 结果不再修改）

Although using false can filter out pseudo filesystems when mountpoints are empty, this has been shown to incorrectly exclude actual physical disks on certain environments.

经过 Review 后决定不修改此项。将参数设为 false 虽然能在挂载点为空时过滤伪文件系统，但在部分环境会错误误排除真实物理磁盘。

To prevent regressions for other environments, keeps to use disk.Partitions(true) as the safer and more compatible default.

为避免对其他环境造成回归，继续使用 disk.Partitions(true) 作为更安全、兼容性更高的默认值。

### Add ZFS deduplication logic

### 添加 ZFS 分区去重逻辑

TrueNAS/ZFS creates many dataset mountpoints under a single physical pool.
Without deduplication, these datasets were previously treated as independent filesystems, causing repeated counting of the same physical storage.

TrueNAS/ZFS 会在一个物理池下创建多层 dataset 挂载点。
如果不去重，这些逻辑子卷会被误当作独立文件系统，从而重复统计同一物理容量。

The new logic includes:
	•	Detect ZFS filesystems
	•	Extract the physical storage pool from dataset paths
	•	Count each physical pool/device once only

新增逻辑包括：
	•	检测 ZFS 文件系统
	•	从 dataset 路径中识别真实物理池
	•	每个物理池或设备只统计一次

This ensures accurate total/used size reporting in ZFS environments.
从而在 ZFS 环境中得到正确的磁盘容量统计。

### Exclude top-level AutoFS trigger mountpoints

### 排除 AutoFS 顶层触发挂载点（autofs）

Linux AutoFS uses a pseudo filesystem (fstype=autofs) as a trigger, not as a real storage device:

systemd-1 on /net  type autofs
/dev/sdb1 on /net/disk1  type ext4
192.168.1.2:/data on /net/nfs  type nfs4

在 Linux 中，AutoFS (fstype=autofs) 只是 自动挂载触发器，并不代表真实存储设备：

systemd-1 挂载在 /net (autofs)
真实磁盘挂载在 /net/disk1 (ext4)
NFS/SMB 则挂载在更深层路径

Excluding autofs ensures safety; even if a user automatically mounts a physical disk via autofs, the actual mount point for ext4/xfs/btrfs/zfs will still appear as an independent partition and will not be excluded. Excluding fstype=autofs only excludes the "entry directory" and does not affect the statistics of the actual physical storage devices.

排除 autofs 安全的，即使用户通过 autofs 自动挂载真实物理盘，实际 ext4/xfs/btrfs/zfs 的挂载点仍会作为独立 Partition 出现，不会被排除。排除 fstype=autofs 仅排除“入口目录”，不影响真正的物理存储设备的统计。

⸻

### Verification on TrueNAS SCALE

### 已在 TrueNAS SCALE 环境验证

The updated agent now correctly reports the actual physical disk capacity (~32 TB), instead of previously inflated values such as 601 TB.

更新后的 agent 正确上报物理容量（约 32 TB），不再出现 601 TB 这类虚高值。

Verification Screenshot / 验证截图

<img width="652" height="406" alt="Screenshot 2025-11-30 at 1 54 23 PM" src="https://github.com/user-attachments/assets/175c2fc5-b415-4306-b3b7-72b8efc02eac" />

⸻