### PR TITLE
fix: support counting host processes inside containers

### DIFF
--- a/cmd/flags/flag.go
+++ b/cmd/flags/flag.go
@@ -26,6 +26,7 @@ type Config struct {
 	CustomIpv4           string  `json:"custom_ipv4" env:"AGENT_CUSTOM_IPV4"`                         // 自定义 IPv4 地址
 	CustomIpv6           string  `json:"custom_ipv6" env:"AGENT_CUSTOM_IPV6"`                         // 自定义 IPv6 地址
 	GetIpAddrFromNic     bool    `json:"get_ip_addr_from_nic" env:"AGENT_GET_IP_ADDR_FROM_NIC"`       // 从网卡获取IP地址
+	HostProc             string  `json:"host_proc" env:"HOST_PROC"`                                   // 容器环境下宿主机/proc目录的挂载点，用于监控宿主机进程
 	ConfigFile           string  `json:"config_file" env:"AGENT_CONFIG_FILE"`                         // JSON配置文件路径
 
 }

--- a/monitoring/unit/process_linux.go
+++ b/monitoring/unit/process_linux.go
@@ -17,6 +17,12 @@ func ProcessCount() (count int) {
 func processCountLinux() (count int) {
 	procDir := "/proc"
 
+	if flags.HostProc != "" {
+		if info, err := os.Stat(flags.HostProc); err == nil && info.IsDir() {
+			procDir = flags.HostProc
+		}
+	}
+
 	entries, err := os.ReadDir(procDir)
 	if err != nil {
 		return 0


### PR DESCRIPTION
这个PR解决了使用docker运行agent时无法正确统计进程数的问题（进程数只有1）。

由于容器的文件系统隔离，agent 读取的 /proc 目录只能统计到容器内的进程（只有 Agent 自己）。

这个 PR 增加了一个 HOST_PROC 配置项。只要将宿主机的 /proc 挂载到容器中（例如 /host/proc），并将环境变量设置为对应的挂载路径，agent就会从该路径统计宿主机的进程数量。

示例 docker-compose.yml：

```docker-compose
volumes:
      - /proc:/host/proc:ro
environment:
      - HOST_PROC: "/host/proc"
```