### PR TITLE
feat: 所有出站连接支持 HTTP 代理

### DIFF
--- a/cmd/autodiscovery.go
+++ b/cmd/autodiscovery.go
@@ -10,7 +10,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/komari-monitor/komari-agent/dnsresolver"
 	"github.com/komari-monitor/komari-agent/utils"
 )
 
@@ -136,7 +138,7 @@ func registerWithAutoDiscovery() error {
 	}
 
 	// 发送请求
-	client := &http.Client{}
+	client := dnsresolver.GetHTTPClient(30 * time.Second)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send register request: %v", err)

--- a/monitoring/unit/ip.go
+++ b/monitoring/unit/ip.go
@@ -16,6 +16,7 @@ var (
 	// 创建适用于IPv4和IPv6的HTTP客户端
 	ipv4HTTPClient = &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				dialer := dnsresolver.GetNetDialer(15 * time.Second)
 				return dialer.DialContext(ctx, "tcp4", addr) // 锁v4防止出现问题
@@ -29,6 +30,7 @@ var (
 	}
 	ipv6HTTPClient = &http.Client{
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				dialer := dnsresolver.GetNetDialer(15 * time.Second)
 				return dialer.DialContext(ctx, "tcp6", addr) // 锁v6防止出现问题

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -192,6 +192,7 @@ func newWSDialer() *websocket.Dialer {
 	d := &websocket.Dialer{
 		HandshakeTimeout: 15 * time.Second,
 		NetDialContext:   dnsresolver.GetDialContext(15 * time.Second),
+		Proxy:            http.ProxyFromEnvironment,
 	}
 	if flags.IgnoreUnsafeCert {
 		d.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}


### PR DESCRIPTION
Closes #66
在无法直接访问外网的环境下（如内网服务器需要通过代理访问互联网），
agent 的 websocket 上报、IP 地址获取、autodiscovery 注册等请求
无法走代理导致连接失败。

现在统一添加 http.ProxyFromEnvironment，
配置 http_proxy/https_proxy 环境变量即可生效，未配置时行为不变。

systemd 配置示例：

[Service]
Environment="http_proxy=http://your-proxy-ip:port"
Environment="https_proxy=http://your-proxy-ip:port"
Environment="HTTP_PROXY=http://your-proxy-ip:port"
Environment="HTTPS_PROXY=http://your-proxy-ip:port"
Environment="no_proxy=localhost,127.0.0.1,::1,172.16.0.0/12"
Environment="NO_PROXY=localhost,127.0.0.1,::1,172.16.0.0/12"