### PR TITLE
fix:安装脚本使用 GitHub 代理时的双重前缀问题

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,28 @@ function Log-Error { param([string]$Message) Write-Host "[ERROR] $Message"    -F
 function Log-Step { param([string]$Message) Write-Host "$Message"    -ForegroundColor Magenta }
 function Log-Config { param([string]$Message) Write-Host "- $Message"    -ForegroundColor White }
 
+# Build a proxy URL without accidentally prefixing the same proxy twice.
+# Some script mirrors rewrite embedded GitHub URLs in the script body, so we
+# assemble the release URL at runtime instead of keeping one literal that may
+# already have been rewritten before PowerShell executes it.
+function Join-ProxyUrl {
+    param(
+        [string]$Proxy,
+        [string]$Target
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Proxy)) {
+        return $Target
+    }
+
+    $trimmedProxy = $Proxy.TrimEnd('/')
+    if ($Target.StartsWith("$trimmedProxy/")) {
+        return $Target
+    }
+
+    return "$trimmedProxy/$Target"
+}
+
 # Default parameters
 $InstallDir = Join-Path $Env:ProgramFiles "Komari"
 $ServiceName = "komari-agent"
@@ -170,6 +192,11 @@ if ($InstallVersion -ne "") {
 # Paths
 $BinaryName = "komari-agent-windows-$arch.exe"
 $AgentPath = Join-Path $InstallDir "komari-agent.exe"
+$GitHubScheme = "https://"
+$GitHubHost = "github.com"
+# Split the GitHub release base into parts so raw script proxies are less
+# likely to rewrite it before the installer actually runs.
+$ReleaseBase = "$GitHubScheme$GitHubHost/komari-monitor/komari-agent/releases"
 
 # Uninstall previous service and binary
 function Uninstall-Previous {
@@ -207,28 +234,26 @@ function Uninstall-Previous {
 Uninstall-Previous
 
 $versionToInstall = ""
+$downloadPath = ""
 if ($InstallVersion -ne "") {
     Log-Info "Attempting to install specified version: $InstallVersion"
     $versionToInstall = $InstallVersion
+    $downloadPath = "download/$versionToInstall"
 }
 else {
-    $ApiUrl = "https://api.github.com/repos/komari-monitor/komari-agent/releases/latest"
-    try {
-        Log-Step "Fetching latest release version from GitHub API..."
-        $release = Invoke-RestMethod -Uri $ApiUrl -UseBasicParsing
-        $versionToInstall = $release.tag_name
-        Log-Success "Latest version fetched: $versionToInstall"
-    }
-    catch {
-        Log-Error "Failed to fetch latest version: $_"
-        exit 1
-    }
+    # Use the GitHub releases "latest/download" endpoint directly so the
+    # installer can stay on the same download path whether or not a proxy is
+    # used, without requiring an extra GitHub API request first.
+    Log-Step "No version specified, downloading the latest release."
+    $versionToInstall = "latest"
+    $downloadPath = "latest/download"
 }
 Log-Success "Installing Komari Agent version: $versionToInstall"
 
 # Construct download URL
 $BinaryName = "komari-agent-windows-$arch.exe"
-$DownloadUrl = if ($GitHubProxy) { "$GitHubProxy/https://github.com/komari-monitor/komari-agent/releases/download/$versionToInstall/$BinaryName" } else { "https://github.com/komari-monitor/komari-agent/releases/download/$versionToInstall/$BinaryName" }
+$ReleaseUrl = "$ReleaseBase/$downloadPath/$BinaryName"
+$DownloadUrl = if ($GitHubProxy) { Join-ProxyUrl $GitHubProxy $ReleaseUrl } else { $ReleaseUrl }
 
 # Download and install
 New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,29 @@ log_config() {
     echo -e "${CYAN}[CONFIG]${NC} $1"
 }
 
+# Build a proxy URL without accidentally prefixing the same proxy twice.
+# Some script mirrors rewrite embedded GitHub URLs in the script body, so we
+# normalize the final release URL at runtime instead of relying on raw string
+# literals that may already have been rewritten upstream.
+join_proxy_url() {
+    local proxy="${1%/}"
+    local target="$2"
+
+    if [ -z "$proxy" ]; then
+        printf '%s' "$target"
+        return
+    fi
+
+    case "$target" in
+        "${proxy}/"*)
+            printf '%s' "$target"
+            ;;
+        *)
+            printf '%s/%s' "$proxy" "$target"
+            ;;
+    esac
+}
+
 # Default values
 service_name="komari-agent"
 target_dir="/opt/komari"
@@ -295,12 +318,19 @@ else
     download_path="download/${version_to_install}"
 fi
 
+github_scheme="https://"
+github_host="github.com"
+# Split the GitHub release base into parts so raw script proxies are less
+# likely to rewrite it before the installer actually runs.
+github_release_base="${github_scheme}${github_host}/komari-monitor/komari-agent/releases"
+github_release_url="${github_release_base}/${download_path}/${file_name}"
+
 if [ -n "$github_proxy" ]; then
     # Use proxy for GitHub releases
-    download_url="${github_proxy}/https://github.com/komari-monitor/komari-agent/releases/${download_path}/${file_name}"
+    download_url="$(join_proxy_url "$github_proxy" "$github_release_url")"
 else
     # Direct access to GitHub releases
-    download_url="https://github.com/komari-monitor/komari-agent/releases/${download_path}/${file_name}"
+    download_url="$github_release_url"
 fi
 
 log_step "Creating installation directory: ${GREEN}$target_dir${NC}"


### PR DESCRIPTION
## 变更说明
- 修复安装脚本在通过代理分发脚本内容、同时又传入 `--install-ghproxy` 时，GitHub 下载地址可能被重复拼接代理前缀的问题
- 在 `install.sh` 和 `install.ps1` 中改为运行时拼接 release 下载地址，避免依赖可能被上游代理改写的完整 GitHub URL 字面量
- 调整 Windows 安装脚本的默认 latest 下载路径，改为直接使用 GitHub 的 `latest/download` 端点，避免额外请求一次 GitHub API

## 问题背景
当安装脚本本身通过类似 `https://gh-proxy.com/raw.githubusercontent.com/.../install.sh` 这样的代理地址获取时，部分代理服务会改写脚本内容中的 GitHub 链接。

如果部署命令同时传入：

`--install-ghproxy https://gh-proxy.com`

脚本内部最终可能会拼出类似下面这样的双重前缀地址：

`https://gh-proxy.com/https://gh-proxy.com/https://github.com/...`

此时下载到的就不是 agent 二进制，而是代理站返回的错误页面，最终导致安装失败或服务无法启动。

## 修复思路
这次修改不改变 `--install-ghproxy` 的用途，而是避免在安装脚本中保留容易被代理服务提前改写的完整 GitHub release 地址。

改为将 GitHub release URL 拆分为多个片段，在脚本运行时再进行拼接，并通过辅助函数统一处理代理前缀拼接逻辑，从而避免重复加前缀。

这样既保留了原本直连安装的行为，也兼容：
- 安装脚本本身通过代理前缀下载
- 安装脚本内部继续通过 `--install-ghproxy` 代理下载 agent 二进制

## 验证情况
已验证：
- 国内 Linux 服务器
- 通过代理方式获取安装脚本
- 同时传入 `--install-ghproxy https://gh-proxy.com`
- 安装成功，服务可正常启动

已验证：
- 国外 Linux 服务器
- 不使用 `--install-ghproxy`
- 直接安装成功，原始直连流程未受影响

未验证：
- `install.ps1` 目前只完成了逻辑修改，尚未在真实 Windows 环境中进行安装测试
