### PR TITLE
fix: 修正 tcping 丢包率测量逻辑

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -220,8 +220,10 @@ func NewPingTask(conn *ws.SafeConn, taskID uint, pingType, pingTarget string) {
 	var err error = nil
 	var latency int64
 	pingResult := -1
-	timeout := 3 * time.Second        // 默认超时时间
-	const highLatencyThreshold = 1000 // ms 阈值
+	timeout := 3 * time.Second           // 默认超时时间
+	const highLatencyThreshold = 1000    // ms 阈值
+	const retryDropThresholdTcping = 800 // ms 重试中延迟降低超过此值则基本认为发生重传
+	// 800ms = SYN/SYN-ACK 首次超时重传 1000ms - 防误判容许 200ms 延迟抖动
 
 	measure := func() (int64, error) {
 		switch pingType {
@@ -238,11 +240,16 @@ func NewPingTask(conn *ws.SafeConn, taskID uint, pingType, pingTarget string) {
 	PingHighLatencyRetries := 3
 	// 首次测量
 	if latency, err = measure(); err == nil {
+		firstLatency := latency
 		if latency > int64(highLatencyThreshold) && PingHighLatencyRetries > 0 {
 			attempts := PingHighLatencyRetries
 			for i := 0; i < attempts; i++ {
 				if second, err2 := measure(); err2 == nil {
 					if second <= int64(highLatencyThreshold) {
+						if pingType == "tcp" && firstLatency-second > int64(retryDropThresholdTcping) {
+							err = errors.New("suspicious retransmission detected in tcp handshake")
+							break
+						}
 						latency = second
 						break
 					}


### PR DESCRIPTION
首次测量发生高ping, 则要么是线路真实延迟确实这么高, 但一般都是发生了丢包触发 SYN/SYN-ACK 握手重传, 对于后者的情况应该视为丢包.
但是目前的逻辑是只要后续 3 次重试有降低到非高ping (<1000ms), 则视为成功, 几乎等于说4次通一次就算通, 拉低了丢包率

具体来说, 假设独立同分布, 单次测量落入高 ping (疑似握手重传)的概率为 $p$ , 目前逻辑下最终被判为失败的概率仅为 $p^4$, 显著低估丢包率 (ICMP就没有这个问题因为底层不重传)

因此增加一个检测逻辑, 如果发现重试中延迟大幅降低了几乎一个SYN/SYN-ACK重传超时的时间 (1000ms, 但考虑波动采用800ms), 则视为首次测量发生重传, 按丢包处理