### PR TITLE
fix: #87 修正网卡列表对通配符匹配的支持

### DIFF
--- a/monitoring/unit/net.go
+++ b/monitoring/unit/net.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -236,19 +237,20 @@ func shouldInclude(nicName string, includeNics, excludeNics map[string]struct{})
 	}
 
 	// 如果定义了白名单，则只包括白名单中的接口
-	if len(includeNics) > 0 {
-		_, ok := includeNics[nicName]
-		return ok
+	for pattern := range includeNics {
+		if matched, _ := filepath.Match(pattern, nicName); matched {
+			return true
+		}
 	}
 
 	// 如果定义了黑名单，则排除黑名单中的接口
-	if len(excludeNics) > 0 {
-		if _, ok := excludeNics[nicName]; ok {
+	for pattern := range excludeNics {
+		if matched, _ := filepath.Match(pattern, nicName); matched {
 			return false
 		}
 	}
 
-	return true
+	return len(includeNics) == 0 // 如果没有定义白名单，则默认包含所有非回环接口
 }
 
 func InterfaceList() ([]string, error) {

--- a/monitoring/unit/net_test.go
+++ b/monitoring/unit/net_test.go
@@ -161,6 +161,15 @@ func TestShouldInclude(t *testing.T) {
 			excludeNics: nil,
 			expected:    false,
 		},
+		{
+			name:        "interface with wildcard pattern in exclude list",
+			nicName:     "tun0",
+			includeNics: nil,
+			excludeNics: map[string]struct{}{
+				"tun*": {},
+			},
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
#87 

现支持在网卡列表配置中使用通配符，比如 `wg?`, `wg*`, `wg[0-9]` 等

引入 `filepath.Match` 实现通配符支持。遵循最小化修改原则，暂不引入复杂的错误处理逻辑，当 pattern 非法时默认跳过匹配。