### PR TITLE
fix(pty): prevent Zsh NOMATCH error during MOTD globbing

### DIFF
--- a/terminal/terminal_unix.go
+++ b/terminal/terminal_unix.go
@@ -67,13 +67,14 @@ func newTerminalImpl() (*terminalImpl, error) {
 		return nil, fmt.Errorf("no supported shell found among %v", defaultShells)
 	}
 
+	shellArgv0 := filepath.Base(shell)
+
 	var prefixCmd string
-	if shell == "zsh" {
+	if shellArgv0 == "zsh" {
 		prefixCmd = "unsetopt NOMATCH 2>/dev/null; "
 	}
 
-	shellArgv0 := filepath.Base(shell)
-	shellCmd := prefixCmd + "for f in /etc/update-motd.d/*; do [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\""
+	shellCmd := prefixCmd + "for f in /etc/update-motd.d/*; do [ -e \"$f\" ] && [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\""
 
 	cmd := exec.Command(shell, "-c", shellCmd)
 	cmd.Args[0] = shellArgv0

--- a/terminal/terminal_unix.go
+++ b/terminal/terminal_unix.go
@@ -67,8 +67,13 @@ func newTerminalImpl() (*terminalImpl, error) {
 		return nil, fmt.Errorf("no supported shell found among %v", defaultShells)
 	}
 
+	var prefixCmd string
+	if shell == "zsh" {
+		prefixCmd = "unsetopt NOMATCH 2>/dev/null; "
+	}
+
 	shellArgv0 := filepath.Base(shell)
-	shellCmd := "for f in /etc/update-motd.d/*; do [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\""
+	shellCmd := prefixCmd + "for f in /etc/update-motd.d/*; do [ -x \"$f\" ] && \"$f\"; done; [ -r /etc/motd ] && cat /etc/motd; exec \"$0\""
 
 	cmd := exec.Command(shell, "-c", shellCmd)
 	cmd.Args[0] = shellArgv0


### PR DESCRIPTION
## Description
This PR fixes a bug where the PTY interactive shell fails to initialize on systems using `zsh` as the default shell, throwing a `zsh:1: no matches found` error.

## The Problem
In the original implementation, `shellCmd` executes a shell loop using wildcards:
`for f in /etc/update-motd.d/*; do ...`

Unlike `bash` or `sh`, `zsh` has a strict default option called `NOMATCH`. If the wildcard pattern `*` fails to match any valid executable files, Zsh will immediately throw a fatal `zsh:1: no matches found: /etc/update-motd.d/*` error and exit.

Because the Zsh process itself is successfully forked, `pty.Start(cmd)` returns `err == nil`, which silently bypasses our Go-level fallback logic (`if err != nil`), leaving the user with a crashed terminal session.