### PR TITLE
fix(remote-exec): execute remote commands as scripts

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -25,7 +26,7 @@ func NewTask(task_id, command string) {
 	if task_id == "" {
 		return
 	}
-	if command == "" {
+	if strings.TrimSpace(command) == "" {
 		uploadTaskResult(task_id, "No command provided", 0, time.Now())
 		return
 	}
@@ -34,18 +35,22 @@ func NewTask(task_id, command string) {
 		return
 	}
 	log.Printf("Executing task %s with command: %s", task_id, command)
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command("powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; "+command)
-	} else {
-		cmd = exec.Command("sh", "-c", command)
+	result, exitCode := runTaskCommand(command)
+	uploadTaskResult(task_id, result, exitCode, time.Now())
+}
+
+func runTaskCommand(command string) (string, int) {
+	cmd, cleanup, err := buildTaskCommand(command)
+	if err != nil {
+		return err.Error(), -1
 	}
+	defer cleanup()
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	err := cmd.Run()
-	finishedAt := time.Now()
+	err = cmd.Run()
 
 	result := stdout.String()
 	if stderr.Len() > 0 {
@@ -56,10 +61,49 @@ func NewTask(task_id, command string) {
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			exitCode = exitError.ExitCode()
+		} else {
+			result = appendErrorResult(result, err.Error())
+			exitCode = -1
 		}
 	}
 
-	uploadTaskResult(task_id, result, exitCode, finishedAt)
+	return result, exitCode
+}
+
+func buildTaskCommand(command string) (*exec.Cmd, func(), error) {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		scriptFile, err := os.CreateTemp("", "komari-task-*.ps1")
+		if err != nil {
+			return nil, func() {}, err
+		}
+		cleanup := func() {
+			_ = os.Remove(scriptFile.Name())
+		}
+		script := "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n" + command
+		if _, err := scriptFile.WriteString(script); err != nil {
+			_ = scriptFile.Close()
+			cleanup()
+			return nil, func() {}, err
+		}
+		if err := scriptFile.Close(); err != nil {
+			cleanup()
+			return nil, func() {}, err
+		}
+		cmd = exec.Command("powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptFile.Name())
+		return cmd, cleanup, nil
+	} else {
+		cmd = exec.Command("sh", "-s")
+		cmd.Stdin = strings.NewReader(command)
+	}
+	return cmd, func() {}, nil
+}
+
+func appendErrorResult(result, err string) string {
+	if result == "" {
+		return err
+	}
+	return result + "\n" + err
 }
 
 func uploadTaskResult(taskID, result string, exitCode int, finishedAt time.Time) {

--- a/server/task.go
+++ b/server/task.go
@@ -54,7 +54,7 @@ func runTaskCommand(command string) (string, int) {
 
 	result := stdout.String()
 	if stderr.Len() > 0 {
-		result += "\n" + stderr.String()
+		result = appendErrorResult(result, stderr.String())
 	}
 	result = strings.ReplaceAll(result, "\r\n", "\n")
 	exitCode := 0
@@ -79,6 +79,11 @@ func buildTaskCommand(command string) (*exec.Cmd, func(), error) {
 		}
 		cleanup := func() {
 			_ = os.Remove(scriptFile.Name())
+		}
+		if _, err := scriptFile.Write([]byte{0xEF, 0xBB, 0xBF}); err != nil {
+			_ = scriptFile.Close()
+			cleanup()
+			return nil, func() {}, err
 		}
 		script := "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8\n" + command
 		if _, err := scriptFile.WriteString(script); err != nil {

--- a/server/task_exec_test.go
+++ b/server/task_exec_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -77,6 +78,52 @@ func TestBuildTaskCommandUsesShellStdinUnix(t *testing.T) {
 	}
 	if cmd.Stdin == nil {
 		t.Fatal("expected command script to be provided on stdin")
+	}
+}
+
+func TestBuildTaskCommandWritesUtf8BomWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows PowerShell script execution test")
+	}
+
+	cmd, cleanup, err := buildTaskCommand("Write-Output '你好'")
+	if err != nil {
+		t.Fatalf("buildTaskCommand returned error: %v", err)
+	}
+	defer cleanup()
+
+	if filepath.Base(cmd.Path) != "powershell.exe" && filepath.Base(cmd.Path) != "powershell" {
+		t.Fatalf("expected powershell command, got %q", cmd.Path)
+	}
+	if len(cmd.Args) == 0 {
+		t.Fatal("expected PowerShell script path in command args")
+	}
+
+	scriptFile := cmd.Args[len(cmd.Args)-1]
+	file, err := filepath.Abs(scriptFile)
+	if err != nil {
+		t.Fatalf("failed to resolve script path: %v", err)
+	}
+
+	f, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		t.Fatalf("failed to evaluate script path: %v", err)
+	}
+	contents, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatalf("failed to read script file: %v", err)
+	}
+	if len(contents) < 3 || contents[0] != 0xEF || contents[1] != 0xBB || contents[2] != 0xBF {
+		t.Fatalf("expected UTF-8 BOM at start of script, got %#v", contents[:min(len(contents), 3)])
+	}
+}
+
+func TestAppendErrorResultAvoidsLeadingNewline(t *testing.T) {
+	if got := appendErrorResult("", "stderr"); got != "stderr" {
+		t.Fatalf("expected stderr without leading newline, got %q", got)
+	}
+	if got := appendErrorResult("stdout", "stderr"); got != "stdout\nstderr" {
+		t.Fatalf("expected stdout and stderr separated by newline, got %q", got)
 	}
 }
 

--- a/server/task_exec_test.go
+++ b/server/task_exec_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRunTaskCommandMultilineUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix shell script execution test")
+	}
+
+	result, exitCode := runTaskCommand("printf '%s\\n' first\nprintf '%s\\n' second\n")
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with result %q", exitCode, result)
+	}
+	if result != "first\nsecond\n" {
+		t.Fatalf("unexpected result %q", result)
+	}
+}
+
+func TestRunTaskCommandEscapingAndWildcardsUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix shell script execution test")
+	}
+
+	tempDir := t.TempDir()
+	command := strings.Join([]string{
+		"cd " + shellSingleQuote(tempDir),
+		"touch alpha.txt beta.log gamma.txt",
+		"printf '%s\\n' \"quoted value with spaces\"",
+		"printf '%s\\n' '*.txt'",
+		"printf '%s ' *.txt",
+		"printf '\\n'",
+	}, "\n")
+
+	result, exitCode := runTaskCommand(command)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with result %q", exitCode, result)
+	}
+	lines := strings.Split(strings.TrimSuffix(result, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 output lines, got %d in %q", len(lines), result)
+	}
+	if lines[0] != "quoted value with spaces" {
+		t.Fatalf("quoted argument was not preserved: %q", lines[0])
+	}
+	if lines[1] != "*.txt" {
+		t.Fatalf("quoted wildcard should remain literal, got %q", lines[1])
+	}
+	expanded := strings.Fields(lines[2])
+	if len(expanded) != 2 || expanded[0] != "alpha.txt" || expanded[1] != "gamma.txt" {
+		t.Fatalf("wildcard expansion mismatch: %q", lines[2])
+	}
+}
+
+func TestBuildTaskCommandUsesShellStdinUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix shell script execution test")
+	}
+
+	cmd, cleanup, err := buildTaskCommand("printf done")
+	if err != nil {
+		t.Fatalf("buildTaskCommand returned error: %v", err)
+	}
+	defer cleanup()
+
+	if filepath.Base(cmd.Path) != "sh" {
+		t.Fatalf("expected sh command, got %q", cmd.Path)
+	}
+	if strings.Join(cmd.Args, " ") != "sh -s" {
+		t.Fatalf("expected sh -s args, got %#v", cmd.Args)
+	}
+	if cmd.Stdin == nil {
+		t.Fatal("expected command script to be provided on stdin")
+	}
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}


### PR DESCRIPTION
- Execute Unix remote commands through shell stdin instead of sh -c arguments
- Execute Windows remote commands through temporary PowerShell script files
- Preserve multiline command content and avoid an extra command-line escaping layer
- Add focused tests for multiline execution, quoting, and wildcard behavior