### PR TITLE
fix(remote-exec): 完善远程命令脚本执行测试

### DIFF
--- a/server/task_exec_test.go
+++ b/server/task_exec_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -54,6 +55,7 @@ func TestRunTaskCommandEscapingAndWildcardsUnix(t *testing.T) {
 		t.Fatalf("quoted wildcard should remain literal, got %q", lines[1])
 	}
 	expanded := strings.Fields(lines[2])
+	sort.Strings(expanded)
 	if len(expanded) != 2 || expanded[0] != "alpha.txt" || expanded[1] != "gamma.txt" {
 		t.Fatalf("wildcard expansion mismatch: %q", lines[2])
 	}

--- a/server/task_exec_windows_test.go
+++ b/server/task_exec_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildTaskCommandCreatesPowerShellScriptWindows(t *testing.T) {
+	cmd, cleanup, err := buildTaskCommand("Write-Output 'hello'")
+	if err != nil {
+		t.Fatalf("buildTaskCommand returned error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	if !isPowerShellExecutable(filepath.Base(cmd.Path)) {
+		t.Fatalf("expected powershell command, got %q", cmd.Path)
+	}
+	if len(cmd.Args) != 6 {
+		t.Fatalf("expected powershell -File args, got %#v", cmd.Args)
+	}
+	if cmd.Args[1] != "-NoProfile" || cmd.Args[2] != "-ExecutionPolicy" || cmd.Args[3] != "Bypass" || cmd.Args[4] != "-File" {
+		t.Fatalf("unexpected powershell args: %#v", cmd.Args)
+	}
+
+	scriptPath := cmd.Args[5]
+	content, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("expected temp script to exist: %v", err)
+	}
+	if !strings.Contains(string(content), "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8") {
+		t.Fatalf("expected UTF-8 output prelude in temp script, got %q", string(content))
+	}
+	if !strings.Contains(string(content), "Write-Output 'hello'") {
+		t.Fatalf("expected command body in temp script, got %q", string(content))
+	}
+
+	cleanup()
+	if _, err := os.Stat(scriptPath); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup to remove temp script, stat error: %v", err)
+	}
+}
+
+func isPowerShellExecutable(name string) bool {
+	return strings.EqualFold(name, "powershell") ||
+		strings.EqualFold(name, "powershell.exe") ||
+		strings.EqualFold(name, "pwsh") ||
+		strings.EqualFold(name, "pwsh.exe")
+}


### PR DESCRIPTION
TLDR: 修复 https://github.com/komari-monitor/komari-agent/pull/97 Github Copilot 自动 review 提出的问题
~老大你好快 我force-push上去发现PR已经merge了~

---
## 变更说明

本 PR 是对已合并的多行远程命令执行支持的跟进修复，主要完善 Agent 侧脚本执行路径的测试覆盖和结果格式稳定性。

主要改动：

- 修复 stderr 单独输出时结果前出现多余空行的问题
- 稳定通配符展开测试，避免断言受 shell 排序或 locale 影响
- 增加 Windows 专用测试，覆盖 PowerShell 临时脚本参数、UTF-8 输出 prelude 和临时文件清理逻辑