### PR TITLE
fix: 修复 Agent 多显卡名称上报格式

### DIFF
--- a/monitoring/unit/gpu.go
+++ b/monitoring/unit/gpu.go
@@ -1,1 +1,37 @@
 package monitoring
+
+import (
+	"fmt"
+	"strings"
+)
+
+func formatGPUNameList(names []string) string {
+	counts := make(map[string]int)
+	order := make([]string, 0, len(names))
+
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if counts[name] == 0 {
+			order = append(order, name)
+		}
+		counts[name]++
+	}
+
+	if len(order) == 0 {
+		return "None"
+	}
+
+	result := make([]string, 0, len(order))
+	for _, name := range order {
+		if counts[name] > 1 {
+			result = append(result, fmt.Sprintf("%s × %d", name, counts[name]))
+			continue
+		}
+		result = append(result, name)
+	}
+
+	return strings.Join(result, ", ")
+}

--- a/monitoring/unit/gpu_darwin.go
+++ b/monitoring/unit/gpu_darwin.go
@@ -25,8 +25,5 @@ func GpuName() string {
 		}
 	}
 
-	if len(names) > 0 {
-		return formatGPUNameList(names)
-	}
-	return "Unknown"
+	return formatGPUNameList(names)
 }

--- a/monitoring/unit/gpu_darwin.go
+++ b/monitoring/unit/gpu_darwin.go
@@ -17,12 +17,16 @@ func GpuName() string {
 	}
 
 	lines := strings.Split(string(output), "\n")
+	var names []string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "Chipset Model:") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "Chipset Model:"))
+			names = append(names, strings.TrimSpace(strings.TrimPrefix(line, "Chipset Model:")))
 		}
 	}
 
+	if len(names) > 0 {
+		return formatGPUNameList(names)
+	}
 	return "Unknown"
 }

--- a/monitoring/unit/gpu_freebsd.go
+++ b/monitoring/unit/gpu_freebsd.go
@@ -25,8 +25,5 @@ func GpuName() string {
 		}
 	}
 
-	if len(names) > 0 {
-		return formatGPUNameList(names)
-	}
-	return "Unknown"
+	return formatGPUNameList(names)
 }

--- a/monitoring/unit/gpu_freebsd.go
+++ b/monitoring/unit/gpu_freebsd.go
@@ -17,12 +17,16 @@ func GpuName() string {
 	}
 
 	lines := strings.Split(string(output), "\n")
+	var names []string
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.Contains(line, "VGA") || strings.Contains(line, "Display") {
-			return line
+			names = append(names, line)
 		}
 	}
 
+	if len(names) > 0 {
+		return formatGPUNameList(names)
+	}
 	return "Unknown"
 }

--- a/monitoring/unit/gpu_linux.go
+++ b/monitoring/unit/gpu_linux.go
@@ -41,7 +41,7 @@ func getFromLspci() string {
 
 	priorityVendors := []string{"nvidia", "amd", "radeon", "intel", "arc", "snap", "qualcomm", "snapdragon"}
 
-	isExcluded := func(name string) bool {
+	isExcludedGPUName := func(name string) bool {
 		for _, pattern := range excludePatterns {
 			if matched, _ := regexp.MatchString(pattern, name); matched {
 				return true
@@ -53,7 +53,7 @@ func getFromLspci() string {
 	var result []string
 	appendName := func(name string) {
 		name = strings.TrimSpace(name)
-		if name == "" || isExcluded(name) {
+		if name == "" || isExcludedGPUName(name) {
 			return
 		}
 		result = append(result, name)
@@ -133,14 +133,14 @@ func getFromSysfsDRM() string {
 	var result []string
 	appendName := func(name string) {
 		name = strings.TrimSpace(name)
-		if name == "" {
+		if name == "" || isExcludedSysfsGPUName(name) {
 			return
 		}
 		result = append(result, name)
 	}
 
 	for _, path := range matches {
-		if matched, _ := regexp.MatchString(`card[0-9]+$`, path); !matched {
+		if !isDRMCardPath(path) {
 			continue
 		}
 
@@ -213,6 +213,28 @@ func getFromSysfsDRM() string {
 	}
 
 	return "None"
+}
+
+func isDRMCardPath(path string) bool {
+	base := filepath.Base(path)
+	if !strings.HasPrefix(base, "card") || len(base) == len("card") {
+		return false
+	}
+	for _, char := range base[len("card"):] {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func isExcludedSysfsGPUName(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "virtio") ||
+		strings.Contains(lower, "vmware") ||
+		strings.Contains(lower, "qxl") ||
+		strings.Contains(lower, "hyper-v") ||
+		strings.Contains(lower, "cirrus")
 }
 
 // parseSocModel 解析设备树 compatible 字符串，提取人性化名称

--- a/monitoring/unit/gpu_linux.go
+++ b/monitoring/unit/gpu_linux.go
@@ -50,6 +50,15 @@ func getFromLspci() string {
 		return false
 	}
 
+	var result []string
+	appendName := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || isExcluded(name) {
+			return
+		}
+		result = append(result, name)
+	}
+
 	extractName := func(line string) string {
 		// 取最后一个冒号之后的内容
 		idx := strings.LastIndex(line, ":")
@@ -77,12 +86,14 @@ func getFromLspci() string {
 		for _, vendor := range priorityVendors {
 			if strings.Contains(lower, vendor) {
 				name := extractName(line)
-				if name != "" && !isExcluded(name) {
-					// 找到独显立刻返回
-					return name
-				}
+				appendName(name)
+				break
 			}
 		}
+	}
+
+	if len(result) > 0 {
+		return formatGPUNameList(result)
 	}
 
 	// 任意非黑名单的 VGA 设备
@@ -90,10 +101,12 @@ func getFromLspci() string {
 		lower := strings.ToLower(line)
 		if strings.Contains(lower, "vga") || strings.Contains(lower, "3d") || strings.Contains(lower, "display") {
 			name := extractName(line)
-			if name != "" && !isExcluded(name) {
-				return name
-			}
+			appendName(name)
 		}
+	}
+
+	if len(result) > 0 {
+		return formatGPUNameList(result)
 	}
 
 	return "None"
@@ -117,7 +130,20 @@ func getFromSysfsDRM() string {
 		"cirrus-qemu": true,
 	}
 
+	var result []string
+	appendName := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		result = append(result, name)
+	}
+
 	for _, path := range matches {
+		if matched, _ := regexp.MatchString(`card[0-9]+$`, path); !matched {
+			continue
+		}
+
 		// 驱动名称
 		driverLink, err := os.Readlink(filepath.Join(path, "device", "driver"))
 		if err != nil {
@@ -140,36 +166,41 @@ func getFromSysfsDRM() string {
 
 		// 有具体型号则直接返回
 		if exactModel != "" {
-			return exactModel
+			appendName(exactModel)
+			continue
 		}
 
 		// 通用的驱动名称映射
 		switch driverName {
 		case "vc4", "vc4-drm":
-			return "Broadcom VideoCore IV/VI (Raspberry Pi)"
+			appendName("Broadcom VideoCore IV/VI (Raspberry Pi)")
 		case "v3d", "v3d-drm":
-			return "Broadcom V3D (Raspberry Pi 4/5)"
+			appendName("Broadcom V3D (Raspberry Pi 4/5)")
 		case "msm", "msm_drm":
-			return "Qualcomm Adreno (Unknown Model)"
+			appendName("Qualcomm Adreno (Unknown Model)")
 		case "panfrost":
-			return "ARM Mali (Panfrost)"
+			appendName("ARM Mali (Panfrost)")
 		case "lima":
-			return "ARM Mali (Lima)"
+			appendName("ARM Mali (Lima)")
 		case "sun4i-drm", "sunxi-drm":
-			return "Allwinner Display Engine"
+			appendName("Allwinner Display Engine")
 		case "tegra":
-			return "NVIDIA Tegra"
+			appendName("NVIDIA Tegra")
 		case "ast": // LXC 容器映射物理显卡
-			return "ASPEED Technology, Inc. ASPEED Graphics Family"
+			appendName("ASPEED Technology, Inc. ASPEED Graphics Family")
 		case "i915", "i915-drm":
-			return "Intel Integrated Graphics"
+			appendName("Intel Integrated Graphics")
 		case "mgag200":
-			return "Matrox G200 Series"
+			appendName("Matrox G200 Series")
+		default:
+			if driverName != "" {
+				appendName("Direct Render Manager " + driverName)
+			}
 		}
+	}
 
-		if driverName != "" {
-			return "Direct Render Manager " + driverName
-		}
+	if len(result) > 0 {
+		return formatGPUNameList(result)
 	}
 
 	// 开发板 Model

--- a/monitoring/unit/gpu_test.go
+++ b/monitoring/unit/gpu_test.go
@@ -11,3 +11,15 @@ func TestGpuName(t *testing.T) {
 	}
 	t.Logf("GPU name: %s", name)
 }
+
+func TestFormatGPUNameList(t *testing.T) {
+	got := formatGPUNameList([]string{
+		"NVIDIA GeForce RTX 4090",
+		"NVIDIA GeForce RTX 4090",
+		"AMD Radeon RX 7900 XTX",
+	})
+	want := "NVIDIA GeForce RTX 4090 × 2, AMD Radeon RX 7900 XTX"
+	if got != want {
+		t.Fatalf("formatGPUNameList() = %q, want %q", got, want)
+	}
+}

--- a/monitoring/unit/gpu_windows.go
+++ b/monitoring/unit/gpu_windows.go
@@ -277,18 +277,17 @@ func GetGPUs() ([]GPUInfo, error) {
 }
 
 func GpuName() string {
-	result := ""
 	gpus, err := GetGPUs()
 	if err != nil {
 		return "Unknown"
 	}
 
 	type GPUKey struct {
-		VendorId uint32
-		DeviceId uint32
-		Revision uint32
+		LUIDHighPart int32
+		LUIDLowPart  uint32
 	}
 	seenGPUs := make(map[GPUKey]bool)
+	var names []string
 
 	for _, gpu := range gpus {
 		if (gpu.Flags & (1 << 1)) != 0 { // DXGI_ADAPTER_FLAG_SOFTWARE
@@ -296,21 +295,17 @@ func GpuName() string {
 		}
 
 		key := GPUKey{
-			VendorId: gpu.VendorId,
-			DeviceId: gpu.DeviceId,
-			Revision: gpu.Revision,
+			LUIDHighPart: gpu.LUIDHighPart,
+			LUIDLowPart:  gpu.LUIDLowPart,
 		}
 
 		if !seenGPUs[key] {
 			seenGPUs[key] = true
 			name := gpu.Name
 			if name != "" {
-				result += name + ", "
+				names = append(names, name)
 			}
 		}
 	}
-	if len(result) > 2 {
-		return result[:len(result)-2]
-	}
-	return "None"
+	return formatGPUNameList(names)
 }

--- a/monitoring/unit/gpu_windows.go
+++ b/monitoring/unit/gpu_windows.go
@@ -286,7 +286,7 @@ func GpuName() string {
 		LUIDHighPart int32
 		LUIDLowPart  uint32
 	}
-	seenGPUs := make(map[GPUKey]bool)
+	seenGPUs := make(map[GPUKey]struct{})
 	var names []string
 
 	for _, gpu := range gpus {
@@ -299,8 +299,8 @@ func GpuName() string {
 			LUIDLowPart:  gpu.LUIDLowPart,
 		}
 
-		if !seenGPUs[key] {
-			seenGPUs[key] = true
+		if _, seen := seenGPUs[key]; !seen {
+			seenGPUs[key] = struct{}{}
 			name := gpu.Name
 			if name != "" {
 				names = append(names, name)


### PR DESCRIPTION
## 变更内容

本 PR 修复 Agent 上报 dashboard 的 `gpu_name` 静态信息时，多显卡场景下名称展示不完整或格式不理想的问题。

主要改动：

- Linux 不再只返回第一个检测到的 GPU，而是收集所有 GPU 名称。
- Windows 使用 DXGI Adapter LUID 识别独立适配器，避免相同型号多卡被错误合并。
- 新增统一的 GPU 名称格式化逻辑：
  - 相同型号多张卡显示为 `GPU Model × n`
  - 不同型号之间使用 `, ` 拼接
- macOS 和 FreeBSD 也接入相同格式化逻辑，保持各平台输出一致。
- 添加格式化逻辑的单元测试。

改动前:
<img width="444" height="73" alt="image" src="https://github.com/user-attachments/assets/5daf7f97-562f-4b47-8388-900c180fb018" />

改动后:
<img width="482" height="61" alt="image" src="https://github.com/user-attachments/assets/ba6f0085-6440-4bf8-8be6-5eff84c25322" />
