### PR TITLE
feat: 支持自定义优先 ipv4 或 ipv6 来连接面板

### DIFF
--- a/cmd/autodiscovery.go
+++ b/cmd/autodiscovery.go
@@ -138,7 +138,7 @@ func registerWithAutoDiscovery() error {
 	}
 
 	// 发送请求
-	client := dnsresolver.GetHTTPClient(30 * time.Second)
+	client := dnsresolver.GetHTTPClientWithPreference(30*time.Second, flags.PreferIPVersion)
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send register request: %v", err)

--- a/cmd/flags/flag.go
+++ b/cmd/flags/flag.go
@@ -30,6 +30,7 @@ type Config struct {
 	ConfigFile           string  `json:"config_file" env:"AGENT_CONFIG_FILE"`                         // JSON配置文件路径
 	ProtocolVersion      int     `json:"protocol_version" env:"AGENT_PROTOCOL_VERSION"`               // 上报协议版本，默认2
 	DisableCompression   bool    `json:"disable_compression" env:"AGENT_DISABLE_COMPRESSION"`         // 禁用v2传输压缩
+	PreferIPVersion      string  `json:"prefer_ip_version" env:"AGENT_PREFER_IP_VERSION"`             // 面板连接优先使用的 IP 版本：4 或 6
 
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -29,20 +30,23 @@ var RootCmd = &cobra.Command{
 	Use:   "komari-agent",
 	Short: "komari agent",
 	Long:  `komari agent`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		loadFromEnv() // 从环境变量加载配置，覆盖解析
 		if flags.ConfigFile != "" {
 			bytes, err := os.ReadFile(flags.ConfigFile)
 			if err != nil {
-				log.Fatalf("Failed to read config file: %v", err)
+				return fmt.Errorf("failed to read config file: %w", err)
 			}
 			err = json.Unmarshal(bytes, flags)
 			if err != nil {
-				log.Fatalf("Failed to parse config file: %v", err)
+				return fmt.Errorf("failed to parse config file: %w", err)
 			}
 		}
 		if flags.ProtocolVersion == 0 {
 			flags.ProtocolVersion = 2
+		}
+		if flags.PreferIPVersion != "" && flags.PreferIPVersion != "4" && flags.PreferIPVersion != "6" {
+			return fmt.Errorf("invalid --prefer-ip-version value %q: expected 4 or 6", flags.PreferIPVersion)
 		}
 		// 捕获中止信号，优雅退出
 		stopCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -96,8 +100,7 @@ var RootCmd = &cobra.Command{
 		if flags.AutoDiscoveryKey != "" {
 			err := handleAutoDiscovery()
 			if err != nil {
-				log.Printf("Auto-discovery failed: %v", err)
-				os.Exit(1)
+				return fmt.Errorf("auto-discovery failed: %w", err)
 			}
 		}
 		diskList, err := monitoring.DiskList()
@@ -148,6 +151,7 @@ func Execute() {
 
 	if err := RootCmd.Execute(); err != nil {
 		log.Println(err)
+		os.Exit(1)
 	}
 }
 
@@ -182,6 +186,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&flags.ConfigFile, "config", "", "Path to the configuration file")
 	RootCmd.PersistentFlags().IntVar(&flags.ProtocolVersion, "protocol-version", 2, "Report protocol version (1 or 2)")
 	RootCmd.PersistentFlags().BoolVar(&flags.DisableCompression, "disable-compression", false, "Disable v2 gzip/permessage-deflate compression")
+	RootCmd.PersistentFlags().StringVar(&flags.PreferIPVersion, "prefer-ip-version", "", "Prefer IP version for dashboard connections: 4 or 6")
 	RootCmd.PersistentFlags().ParseErrorsWhitelist.UnknownFlags = true
 }
 

--- a/dnsresolver/resolver.go
+++ b/dnsresolver/resolver.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +42,7 @@ var (
 type httpClientKey struct {
 	timeout          time.Duration
 	ignoreUnsafeCert bool
+	preferIPVersion  string
 }
 
 // SetCustomDNSServer 设置自定义DNS服务器
@@ -120,9 +120,12 @@ func GetCustomResolver() *net.Resolver {
 	}
 }
 
-// GetHTTPClient 返回一个使用自定义DNS解析器的HTTP客户端
 // buildTransport 构建带有自定义解析/拨号策略的 HTTP 传输层，可注入 TLS 配置
 func buildTransport(timeout time.Duration, tlsConfig *tls.Config) *http.Transport {
+	return buildTransportWithPreference(timeout, tlsConfig, "")
+}
+
+func buildTransportWithPreference(timeout time.Duration, tlsConfig *tls.Config, preferIPVersion string) *http.Transport {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
@@ -138,20 +141,7 @@ func buildTransport(timeout time.Duration, tlsConfig *tls.Config) *http.Transpor
 			if err != nil {
 				return nil, err
 			}
-			// 根据本机是否具备 IPv4 动态排序
-			preferIPv4 := preferIPv4First()
-			sort.SliceStable(ips, func(i, j int) bool {
-				ip1 := net.ParseIP(ips[i])
-				ip2 := net.ParseIP(ips[j])
-				if ip1 == nil || ip2 == nil {
-					return false
-				}
-				if preferIPv4 {
-					return ip1.To4() != nil && ip2.To4() == nil
-				}
-				// IPv6 优先
-				return ip1.To4() == nil && ip2.To4() != nil
-			})
+			sortIPsByPreference(ips, preferIPVersion)
 			for _, ip := range ips {
 				dialer := &net.Dialer{
 					Timeout:   timeout,
@@ -177,19 +167,29 @@ func buildTransport(timeout time.Duration, tlsConfig *tls.Config) *http.Transpor
 }
 
 func GetHTTPClient(timeout time.Duration) *http.Client {
+	return getHTTPClient(timeout, "")
+}
+
+// GetHTTPClientWithPreference 返回一个使用自定义解析器并按指定 IP 版本排序的 HTTP 客户端。
+// preferIPVersion 为 "4" 或 "6" 时固定优先对应地址；为空时保留自动选择逻辑。
+func GetHTTPClientWithPreference(timeout time.Duration, preferIPVersion string) *http.Client {
+	return getHTTPClient(timeout, normalizeIPVersionPreference(preferIPVersion))
+}
+
+func getHTTPClient(timeout time.Duration, preferIPVersion string) *http.Client {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
-	key := httpClientKey{timeout: timeout, ignoreUnsafeCert: flags.IgnoreUnsafeCert}
+	key := httpClientKey{timeout: timeout, ignoreUnsafeCert: flags.IgnoreUnsafeCert, preferIPVersion: preferIPVersion}
 	httpClientMu.Lock()
 	defer httpClientMu.Unlock()
 	if client := httpClients[key]; client != nil {
 		return client
 	}
 	client := &http.Client{
-		Transport: buildTransport(timeout, &tls.Config{
+		Transport: buildTransportWithPreference(timeout, &tls.Config{
 			InsecureSkipVerify: flags.IgnoreUnsafeCert,
-		}),
+		}, preferIPVersion),
 		Timeout: timeout,
 	}
 	httpClients[key] = client
@@ -211,14 +211,21 @@ func GetNetDialer(timeout time.Duration) *net.Dialer {
 
 // GetDialContext 返回一个自定义 DialContext：
 // - 使用自定义解析器解析主机名
-// - 优先尝试 IPv4，再尝试 IPv6
+// - 根据本机网络自动选择 IPv4 或 IPv6 优先
 // - 逐个 IP 进行连接尝试，直到成功或全部失败
 func GetDialContext(timeout time.Duration) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return GetDialContextWithPreference(timeout, "")
+}
+
+// GetDialContextWithPreference 返回一个可显式指定 IPv4/IPv6 优先级的 DialContext。
+// preferIPVersion 为 "4" 或 "6" 时固定优先对应地址；为空时保留自动选择逻辑。
+func GetDialContextWithPreference(timeout time.Duration, preferIPVersion string) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	if timeout <= 0 {
 		timeout = 15 * time.Second
 	}
 
 	resolver := GetCustomResolver()
+	preferIPVersion = normalizeIPVersionPreference(preferIPVersion)
 
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		host, port, err := net.SplitHostPort(addr)
@@ -235,20 +242,7 @@ func GetDialContext(timeout time.Duration) func(ctx context.Context, network, ad
 			return nil, err
 		}
 
-		// 根据本机是否具备 IPv4 动态排序
-		preferIPv4 := preferIPv4First()
-		sort.SliceStable(ips, func(i, j int) bool {
-			ip1 := net.ParseIP(ips[i])
-			ip2 := net.ParseIP(ips[j])
-			if ip1 == nil || ip2 == nil {
-				return false
-			}
-			if preferIPv4 {
-				return ip1.To4() != nil && ip2.To4() == nil
-			}
-			// IPv6 优先
-			return ip1.To4() == nil && ip2.To4() != nil
-		})
+		sortIPsByPreference(ips, preferIPVersion)
 
 		// 逐个 IP 尝试连接
 		for _, ip := range ips {
@@ -264,6 +258,40 @@ func GetDialContext(timeout time.Duration) func(ctx context.Context, network, ad
 		}
 		return nil, fmt.Errorf("failed to dial to any of the resolved IPs")
 	}
+}
+
+func normalizeIPVersionPreference(preferIPVersion string) string {
+	if preferIPVersion == "4" || preferIPVersion == "6" {
+		return preferIPVersion
+	}
+	return ""
+}
+
+func sortIPsByPreference(ips []string, preferIPVersion string) {
+	preferIPVersion = normalizeIPVersionPreference(preferIPVersion)
+	if preferIPVersion == "" {
+		// 根据本机是否具备 IPv4 动态排序
+		if preferIPv4First() {
+			preferIPVersion = "4"
+		} else {
+			preferIPVersion = "6"
+		}
+	}
+
+	preferred := make([]string, 0, len(ips))
+	others := make([]string, 0, len(ips))
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		isIPv4 := parsedIP != nil && parsedIP.To4() != nil
+		isIPv6 := parsedIP != nil && parsedIP.To4() == nil
+		if (preferIPVersion == "4" && isIPv4) || (preferIPVersion == "6" && isIPv6) {
+			preferred = append(preferred, ip)
+		} else {
+			others = append(others, ip)
+		}
+	}
+	n := copy(ips, preferred)
+	copy(ips[n:], others)
 }
 
 // preferIPv4First 检测本机是否存在可用的 IPv4 地址，若没有则在连接尝试中优先 IPv6

--- a/server/basicInfo.go
+++ b/server/basicInfo.go
@@ -124,7 +124,7 @@ func tryUploadDataWithProtocol(data map[string]interface{}, protocolVersion int)
 		req.Header.Set("CF-Access-Client-Secret", flags.CFAccessClientSecret)
 	}
 
-	client := dnsresolver.GetHTTPClient(30 * time.Second)
+	client := dnsresolver.GetHTTPClientWithPreference(30*time.Second, flags.PreferIPVersion)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/server/task.go
+++ b/server/task.go
@@ -122,7 +122,7 @@ func uploadTaskResult(taskID, result string, exitCode int, finishedAt time.Time)
 	jsonData, _ := json.Marshal(payload)
 	endpoint := flags.Endpoint + "/api/clients/task/result?token=" + flags.Token
 
-	client := dnsresolver.GetHTTPClient(30 * time.Second)
+	client := dnsresolver.GetHTTPClientWithPreference(30*time.Second, flags.PreferIPVersion)
 	maxRetry := flags.MaxRetries
 	for attempt := 0; attempt <= maxRetry; attempt++ {
 		req, err := http.NewRequest("POST", endpoint, bytes.NewReader(jsonData))
@@ -387,7 +387,7 @@ func postV2RPC(payload interface{}) error {
 		req.Header.Set("CF-Access-Client-Id", flags.CFAccessClientID)
 		req.Header.Set("CF-Access-Client-Secret", flags.CFAccessClientSecret)
 	}
-	client := dnsresolver.GetHTTPClient(30 * time.Second)
+	client := dnsresolver.GetHTTPClientWithPreference(30*time.Second, flags.PreferIPVersion)
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -273,7 +273,7 @@ func postV2RequestContext(ctx context.Context, payload []byte) (*v2.Response, er
 		req.Header.Set("CF-Access-Client-Id", flags.CFAccessClientID)
 		req.Header.Set("CF-Access-Client-Secret", flags.CFAccessClientSecret)
 	}
-	client := dnsresolver.GetHTTPClient(35 * time.Second)
+	client := dnsresolver.GetHTTPClientWithPreference(35*time.Second, flags.PreferIPVersion)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -504,7 +504,7 @@ func establishTerminalConnection(token, id, endpoint string) {
 func newWSDialer() *websocket.Dialer {
 	d := &websocket.Dialer{
 		HandshakeTimeout:  15 * time.Second,
-		NetDialContext:    dnsresolver.GetDialContext(15 * time.Second),
+		NetDialContext:    dnsresolver.GetDialContextWithPreference(15*time.Second, flags.PreferIPVersion),
 		Proxy:             http.ProxyFromEnvironment,
 		EnableCompression: !flags.DisableCompression,
 	}


### PR DESCRIPTION
## 变更内容

本 PR 为 komari-agent 新增 `--prefer-ip-version` 参数，用于指定连接面板地址时优先尝试 IPv4 或 IPv6。

支持的配置方式：

- CLI：`--prefer-ip-version 4` 或 `--prefer-ip-version 6`
- 环境变量：`AGENT_PREFER_IP_VERSION`
- JSON 配置：`prefer_ip_version`

## 行为说明

该配置仅影响 Agent 连接 Komari 面板相关的请求，包括：

- WebSocket 实时上报
- v2 POST fallback 上报
- 基础信息上报
- 自动发现注册
- 任务 / Ping 结果回传
- 终端 WebSocket 连接

未设置时保留原有自动选择逻辑。Updater、公网 IP 获取、Ping 任务目标解析等其他域名访问不受影响。