### PR TITLE
perf: 在 Linux 直接对 /proc/net 进行行数统计实现快速连接数测量

### DIFF
--- a/monitoring/unit/net.go
+++ b/monitoring/unit/net.go
@@ -1,8 +1,11 @@
 package monitoring
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -12,6 +15,28 @@ import (
 )
 
 func ConnectionsCount() (tcpCount, udpCount int, err error) {
+	if runtime.GOOS == "linux" {
+		return connectionsCountWithProcFallback(procRoot(), gopsutilConnectionsCount)
+	}
+
+	return gopsutilConnectionsCount()
+}
+
+func connectionsCountWithProcFallback(root string, fallback func() (int, int, error)) (tcpCount, udpCount int, err error) {
+	var procErr error
+	tcpCount, udpCount, procErr = procNetConnectionsCount(root)
+	if procErr == nil {
+		return tcpCount, udpCount, nil
+	}
+
+	tcpCount, udpCount, err = fallback()
+	if err != nil && procErr != nil {
+		return 0, 0, fmt.Errorf("proc net fast path failed: %w; gopsutil fallback failed: %w", procErr, err)
+	}
+	return tcpCount, udpCount, err
+}
+
+func gopsutilConnectionsCount() (tcpCount, udpCount int, err error) {
 	tcps, err := net.Connections("tcp")
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get TCP connections: %w", err)
@@ -22,6 +47,67 @@ func ConnectionsCount() (tcpCount, udpCount int, err error) {
 	}
 
 	return len(tcps), len(udps), nil
+}
+
+func procRoot() string {
+	if flags.HostProc != "" {
+		return flags.HostProc
+	}
+	return "/proc"
+}
+
+func procNetConnectionsCount(root string) (tcpCount, udpCount int, err error) {
+	tcpCount, err = countProcNetFiles(root, "tcp", "tcp6")
+	if err != nil {
+		return 0, 0, err
+	}
+	udpCount, err = countProcNetFiles(root, "udp", "udp6")
+	if err != nil {
+		return 0, 0, err
+	}
+	return tcpCount, udpCount, nil
+}
+
+func countProcNetFiles(root string, names ...string) (int, error) {
+	total := 0
+	readAny := false
+	for _, name := range names {
+		count, err := countProcNetFile(filepath.Join(root, "net", name))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, err
+		}
+		total += count
+		readAny = true
+	}
+	if !readAny {
+		return 0, fmt.Errorf("no proc net files found under %s", filepath.Join(root, "net"))
+	}
+	return total, nil
+}
+
+func countProcNetFile(path string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	count := 0
+	scanner := bufio.NewScanner(file)
+	header := true
+	for scanner.Scan() {
+		if header {
+			header = false
+			continue
+		}
+		if strings.TrimSpace(scanner.Text()) != "" {
+			count++
+		}
+	}
+	return count, scanner.Err()
 }
 
 var (

--- a/monitoring/unit/net_test.go
+++ b/monitoring/unit/net_test.go
@@ -1,6 +1,9 @@
 package monitoring
 
 import (
+	"errors"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +22,35 @@ func TestConnectionsCount(t *testing.T) {
 	}
 
 	t.Logf("TCP connections: %d, UDP connections: %d", tcpCount, udpCount)
+}
+
+func TestConnectionsCountCombinesProcAndFallbackErrors(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("proc net fast path only runs on linux")
+	}
+
+	fallbackErr := errors.New("fallback unavailable")
+	fallback := func() (int, int, error) {
+		return 0, 0, fallbackErr
+	}
+
+	tcpCount, udpCount, err := connectionsCountWithProcFallback(t.TempDir(), fallback)
+	if err == nil {
+		t.Fatal("expected combined error, got nil")
+	}
+	if tcpCount != 0 || udpCount != 0 {
+		t.Fatalf("expected zero counts on failure, got tcp=%d udp=%d", tcpCount, udpCount)
+	}
+	if !errors.Is(err, fallbackErr) {
+		t.Fatalf("expected combined error to wrap fallback error, got %v", err)
+	}
+
+	errText := err.Error()
+	for _, want := range []string{"proc net fast path failed", "no proc net files found", "gopsutil fallback failed"} {
+		if !strings.Contains(errText, want) {
+			t.Fatalf("expected error %q to contain %q", errText, want)
+		}
+	}
 }
 
 func TestParseNics(t *testing.T) {


### PR DESCRIPTION
## 变更说明

优化 Linux 连接数统计

   - Linux 下优先通过 `/proc/net/tcp`, `/proc/net/tcp6`, `/proc/net/udp`, `/proc/net/udp6` 直接统计行数
   - `gopsutil/net.Connections()` 内部开销过高, 避免为了两个计数字段构造完整连接列表
   - 非 Linux 或 `/proc` 快路径失败时仍 fallback 到原 gopsutil 实现