### PR TITLE
PR 修复：处理 endpoint 末尾斜杠，避免 URL 出现双斜杠

### DIFF
--- a/server/task.go
+++ b/server/task.go
@@ -120,7 +120,7 @@ func uploadTaskResult(taskID, result string, exitCode int, finishedAt time.Time)
 	}
 
 	jsonData, _ := json.Marshal(payload)
-	endpoint := flags.Endpoint + "/api/clients/task/result?token=" + flags.Token
+	endpoint := strings.TrimSuffix(flags.Endpoint, "/") + "/api/clients/task/result?token=" + flags.Token
 
 	client := dnsresolver.GetHTTPClient(30 * time.Second)
 	maxRetry := flags.MaxRetries


### PR DESCRIPTION
# PR 修复：处理 endpoint 末尾斜杠，避免 URL 出现双斜杠
## PR 信息
- 关联文件：server/task.go

## 问题说明
原代码直接拼接服务地址与接口路径，未处理配置中 endpoint 末尾带 `/` 的场景。
若配置 `flags.Endpoint` 为 `https://xxx.com/`，拼接后会生成 `https://xxx.com//api/clients/task/result`。
Nginx、Cloudflare Access 等网关对双斜杠路径校验严格，会引发 404/401 请求失败。

## 修复方案
使用 `strings.TrimSuffix` 清除地址尾部多余斜杠后再拼接接口路径，统一 URL 格式，兼容带/不带尾斜杠两种配置写法，对齐项目 v2 rpc 接口现有规范。

## 代码 Diff
```diff
	jsonData, _ := json.Marshal(payload)
-	endpoint := flags.Endpoint + "/api/clients/task/result?token=" + flags.Token
+	endpoint := strings.TrimSuffix(flags.Endpoint, "/") + "/api/clients/task/result?token=" + flags.Token