### PR TITLE
perf: 优化采样间隔并降低上报阻塞

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -164,7 +164,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&flags.DisableAutoUpdate, "disable-auto-update", false, "Disable automatic updates")
 	RootCmd.PersistentFlags().BoolVar(&flags.DisableWebSsh, "disable-web-ssh", false, "Disable remote control(web ssh and rce)")
 	//RootCmd.PersistentFlags().BoolVar(&flags.MemoryModeAvailable, "memory-mode-available", false, "[deprecated]Report memory as available instead of used.")
-	RootCmd.PersistentFlags().Float64VarP(&flags.Interval, "interval", "i", 1.0, "Interval in seconds")
+	RootCmd.PersistentFlags().Float64VarP(&flags.Interval, "interval", "i", 3.0, "Interval in seconds")
 	RootCmd.PersistentFlags().BoolVarP(&flags.IgnoreUnsafeCert, "ignore-unsafe-cert", "u", false, "Ignore unsafe certificate errors")
 	RootCmd.PersistentFlags().IntVarP(&flags.MaxRetries, "max-retries", "r", 3, "Maximum number of retries")
 	RootCmd.PersistentFlags().IntVarP(&flags.ReconnectInterval, "reconnect-interval", "c", 5, "Reconnect interval in seconds")

--- a/monitoring/unit/cpu.go
+++ b/monitoring/unit/cpu.go
@@ -21,6 +21,17 @@ type CpuInfo struct {
 }
 
 func Cpu() CpuInfo {
+	cpuinfo := CpuStaticInfo()
+
+	percentages, err := cpu.Percent(0, false)
+	if err == nil && len(percentages) > 0 {
+		cpuinfo.CPUUsage = percentages[0]
+	}
+
+	return cpuinfo
+}
+
+func CpuStaticInfo() CpuInfo {
 	cpuinfo := CpuInfo{
 		CPUName:          "Unknown",
 		CPUArchitecture:  runtime.GOARCH,
@@ -55,11 +66,6 @@ func Cpu() CpuInfo {
 	physicalCores, err := cpu.Counts(false)
 	if err == nil && physicalCores > 0 {
 		cpuinfo.CPUPhysicalCores = physicalCores
-	}
-
-	percentages, err := cpu.Percent(0, false)
-	if err == nil && len(percentages) > 0 {
-		cpuinfo.CPUUsage = percentages[0]
 	}
 
 	return cpuinfo

--- a/monitoring/unit/cpu.go
+++ b/monitoring/unit/cpu.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	pkg_flags "github.com/komari-monitor/komari-agent/cmd/flags"
 	"github.com/shirou/gopsutil/v4/cpu"
@@ -58,7 +57,7 @@ func Cpu() CpuInfo {
 		cpuinfo.CPUPhysicalCores = physicalCores
 	}
 
-	percentages, err := cpu.Percent(1*time.Second, false)
+	percentages, err := cpu.Percent(0, false)
 	if err == nil && len(percentages) > 0 {
 		cpuinfo.CPUUsage = percentages[0]
 	}

--- a/monitoring/unit/net.go
+++ b/monitoring/unit/net.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/komari-monitor/komari-agent/monitoring/netstatic"
@@ -241,7 +242,7 @@ func NetworkSpeed() (totalUp, totalDown, upSpeed, downSpeed uint64, err error) {
 			}
 		}
 
-		// 对于实时速度，仍然使用gopsutil方法
+		// 对于实时速度，仍然使用网卡累计计数器差值
 		_, _, upSpeed, downSpeed, err = getNetworkSpeedFallback(includeNics, excludeNics)
 		if err != nil {
 			return totalUp, totalDown, 0, 0, err
@@ -255,52 +256,75 @@ func NetworkSpeed() (totalUp, totalDown, upSpeed, downSpeed uint64, err error) {
 }
 
 func getNetworkSpeedFallback(includeNics, excludeNics map[string]struct{}) (totalUp, totalDown, upSpeed, downSpeed uint64, err error) {
-	// 获取第一次网络IO计数器
-	ioCounters1, err := net.IOCounters(true)
+	totalUp, totalDown, err = collectNetworkTotals(includeNics, excludeNics)
 	if err != nil {
-		return 0, 0, 0, 0, fmt.Errorf("failed to get network IO counters: %w", err)
+		return 0, 0, 0, 0, err
 	}
 
-	if len(ioCounters1) == 0 {
-		return 0, 0, 0, 0, fmt.Errorf("no network interfaces found")
+	upSpeed, downSpeed = updateNetworkSpeedSample(totalUp, totalDown, time.Now())
+	return totalUp, totalDown, upSpeed, downSpeed, nil
+}
+
+func collectNetworkTotals(includeNics, excludeNics map[string]struct{}) (totalUp, totalDown uint64, err error) {
+	ioCounters, err := net.IOCounters(true)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get network IO counters: %w", err)
 	}
 
-	// 统计第一次所有非回环接口的流量
-	var totalUp1, totalDown1 uint64
-	for _, interfaceStats := range ioCounters1 {
+	if len(ioCounters) == 0 {
+		return 0, 0, fmt.Errorf("no network interfaces found")
+	}
+
+	for _, interfaceStats := range ioCounters {
 		if shouldInclude(interfaceStats.Name, includeNics, excludeNics) {
-			totalUp1 += interfaceStats.BytesSent
-			totalDown1 += interfaceStats.BytesRecv
+			totalUp += interfaceStats.BytesSent
+			totalDown += interfaceStats.BytesRecv
 		}
 	}
 
-	// 等待1秒
-	time.Sleep(time.Second)
+	return totalUp, totalDown, nil
+}
 
-	// 获取第二次网络IO计数器
-	ioCounters2, err := net.IOCounters(true)
-	if err != nil {
-		return 0, 0, 0, 0, fmt.Errorf("failed to get network IO counters: %w", err)
+type networkSpeedState struct {
+	sync.Mutex
+	totalUp   uint64
+	totalDown uint64
+	sampledAt time.Time
+}
+
+var networkSpeedSample networkSpeedState
+
+func updateNetworkSpeedSample(totalUp, totalDown uint64, now time.Time) (upSpeed, downSpeed uint64) {
+	networkSpeedSample.Lock()
+	defer networkSpeedSample.Unlock()
+
+	if networkSpeedSample.sampledAt.IsZero() {
+		networkSpeedSample.totalUp = totalUp
+		networkSpeedSample.totalDown = totalDown
+		networkSpeedSample.sampledAt = now
+		return 0, 0
 	}
 
-	if len(ioCounters2) == 0 {
-		return 0, 0, 0, 0, fmt.Errorf("no network interfaces found")
+	elapsed := now.Sub(networkSpeedSample.sampledAt).Seconds()
+	if elapsed <= 0 {
+		return 0, 0
 	}
 
-	// 统计第二次所有非回环接口的流量
-	var totalUp2, totalDown2 uint64
-	for _, interfaceStats := range ioCounters2 {
-		if shouldInclude(interfaceStats.Name, includeNics, excludeNics) {
-			totalUp2 += interfaceStats.BytesSent
-			totalDown2 += interfaceStats.BytesRecv
-		}
+	upDelta := safeCounterDelta(totalUp, networkSpeedSample.totalUp)
+	downDelta := safeCounterDelta(totalDown, networkSpeedSample.totalDown)
+
+	networkSpeedSample.totalUp = totalUp
+	networkSpeedSample.totalDown = totalDown
+	networkSpeedSample.sampledAt = now
+
+	return uint64(float64(upDelta) / elapsed), uint64(float64(downDelta) / elapsed)
+}
+
+func safeCounterDelta(current, previous uint64) uint64 {
+	if current >= previous {
+		return current - previous
 	}
-
-	// 计算速度 (每秒的速率)
-	upSpeed = totalUp2 - totalUp1
-	downSpeed = totalDown2 - totalDown1
-
-	return totalUp2, totalDown2, upSpeed, downSpeed, nil
+	return 0
 }
 
 func parseNics(nics string) map[string]struct{} {

--- a/server/basicInfo.go
+++ b/server/basicInfo.go
@@ -38,7 +38,7 @@ func UpdateBasicInfo() {
 	}
 }
 func uploadBasicInfo() error {
-	cpu := monitoring.Cpu()
+	cpu := monitoring.CpuStaticInfo()
 
 	osname := monitoring.OSName()
 	kernelVersion := monitoring.KernelVersion()

--- a/server/websocket.go
+++ b/server/websocket.go
@@ -38,7 +38,7 @@ func EstablishWebSocketConnection() {
 		resetConnectionProtocolVersion()
 	}()
 	var err error
-	interval := math.Max(1, flags.Interval-1)
+	interval := math.Max(1, flags.Interval)
 
 	dataTicker := time.NewTicker(time.Duration(interval * float64(time.Second)))
 	defer dataTicker.Stop()


### PR DESCRIPTION
## 变更内容

- 将 CPU 使用率采样从阻塞式 `cpu.Percent(1s)` 改为基于上次采样的非阻塞 `cpu.Percent(0)`。
- 将基础信息上报改为只读取 CPU 静态信息，避免重置实时上报路径的 CPU 采样基线。
- 将网络速率计算从“两次读取网卡计数器 + sleep 1s”改为基于上次上报计数器差值计算。
- 将默认上报间隔从 `1s` 调整为 `3s`。
- 移除原有 `interval - 1s` 的补偿逻辑，使配置的采样/上报间隔与实际 ticker 间隔一致。

## 背景

旧逻辑中，默认配置虽然是 `1s` 上报间隔，但 CPU 和网络速率采样各自会阻塞约 `1s`，导致实际上报周期接近 `2s`，且 CPU 与网络速率并不是同一时间窗口内的采样结果。

本 PR 移除这两个阻塞采样点，并显式将默认上报间隔调整为 `3s`，避免非阻塞后默认部署实际变为每秒上报一次。

此外，`cpu.Percent(0)` 依赖进程内的上次采样状态。基础信息上报现在不再调用带 CPU 使用率采样的 `Cpu()`，避免启动和周期性 basic info 上传干扰实时 report 的 CPU 使用率采样窗口。

## 兼容性

- 上报 JSON 结构不变。
- 基础信息上报字段不变。
- `--interval` 语义发生调整：现在实际上报间隔与配置值一致，不再自动减去 `1s`。
- 网络速率首个采样点没有上一轮计数器基线，因此首轮速率为 `0`，后续按两次上报间隔之间的计数器差值计算。