### PR TITLE
fix：磁盘统计排除 nullfs，避免 macOS 特殊情况下重复统计磁盘

### DIFF
--- a/monitoring/unit/disk.go
+++ b/monitoring/unit/disk.go
@@ -135,6 +135,7 @@ func isPhysicalDisk(part disk.PartitionStat) bool {
 		"debugfs",
 		"binfmt_misc",
 		"securityfs",
+		"nullfs",
 	}
 	for _, fs := range fstypeToExclude {
 		if fstype == fs || strings.HasPrefix(fstype, fs) {


### PR DESCRIPTION
macOS 下部分 iOS/iPadOS 应用运行时，会通过 nullfs 将 App 的 Wrapper 目录挂载到 `/private/var/folders` 下的临时目录

gopsutil 获取磁盘分区时会将 nullfs 识别为独立分区

由于 nullfs 不是真实的物理存储，如果不排除可能会导致同一块磁盘被重复统计

在部分情况下 macOS 即使退出应用、甚至重启系统后，该 nullfs 挂载仍然存在

所以将 nullfs 加入文件系统排除列表，避免在 macOS 下因为 nullfs 导致磁盘容量重复统计