### PR TITLE
fix: 在 rocm-smi 不可用时从 amdgpu sysfs 读取 GPU 占用

### DIFF
--- a/monitoring/unit/gpu_amd_sysfs_linux.go
+++ b/monitoring/unit/gpu_amd_sysfs_linux.go
@@ -1,0 +1,195 @@
+//go:build linux
+
+package monitoring
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func getAMDSysfsDetailedInfo() ([]DetailedGPUInfo, error) {
+	cards, err := listAMDSysfsCards()
+	if err != nil {
+		return nil, err
+	}
+
+	fallbackName := GpuName()
+	infos := make([]DetailedGPUInfo, 0, len(cards))
+	for _, card := range cards {
+		name := card.name
+		if name == "" || name == "None" {
+			name = fallbackName
+		}
+		if name == "" || name == "None" {
+			name = "AMD GPU"
+		}
+		infos = append(infos, DetailedGPUInfo{
+			Name:        name,
+			MemoryTotal: card.memoryTotal,
+			MemoryUsed:  card.memoryUsed,
+			Utilization: card.utilization,
+			Temperature: card.temperature,
+		})
+	}
+	return infos, nil
+}
+
+func getAMDSysfsDetailedHost() ([]string, error) {
+	infos, err := getAMDSysfsDetailedInfo()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(infos))
+	for _, info := range infos {
+		if info.Name != "" {
+			names = append(names, info.Name)
+		}
+	}
+	if len(names) == 0 {
+		return nil, errors.New("no AMD GPU found in sysfs")
+	}
+	return names, nil
+}
+
+func getAMDSysfsDetailedStat() ([]float64, error) {
+	infos, err := getAMDSysfsDetailedInfo()
+	if err != nil {
+		return nil, err
+	}
+	usage := make([]float64, 0, len(infos))
+	for _, info := range infos {
+		usage = append(usage, info.Utilization)
+	}
+	return usage, nil
+}
+
+type amdSysfsCard struct {
+	name        string
+	memoryTotal uint64
+	memoryUsed  uint64
+	utilization float64
+	temperature uint64
+}
+
+func listAMDSysfsCards() ([]amdSysfsCard, error) {
+	matches, err := filepath.Glob("/sys/class/drm/card*")
+	if err != nil {
+		return nil, err
+	}
+
+	var cards []amdSysfsCard
+	for _, path := range matches {
+		if !isDRMCardPath(path) {
+			continue
+		}
+
+		deviceDir := filepath.Join(path, "device")
+		driverLink, err := os.Readlink(filepath.Join(deviceDir, "driver"))
+		if err != nil {
+			continue
+		}
+		if filepath.Base(driverLink) != "amdgpu" {
+			continue
+		}
+
+		busy, err := readSysfsFloat(filepath.Join(deviceDir, "gpu_busy_percent"))
+		if err != nil {
+			continue
+		}
+
+		card := amdSysfsCard{
+			name:        readAMDSysfsName(deviceDir),
+			utilization: busy,
+			temperature: readAMDSysfsTemperature(deviceDir),
+		}
+		if total, err := readSysfsUint(filepath.Join(deviceDir, "mem_info_vram_total")); err == nil {
+			card.memoryTotal = total
+		}
+		if used, err := readSysfsUint(filepath.Join(deviceDir, "mem_info_vram_used")); err == nil {
+			card.memoryUsed = used
+		}
+		cards = append(cards, card)
+	}
+
+	if len(cards) == 0 {
+		return nil, errors.New("no amdgpu sysfs metrics found")
+	}
+	return cards, nil
+}
+
+func readAMDSysfsName(deviceDir string) string {
+	for _, name := range []string{"product_name", "product_description"} {
+		data, err := os.ReadFile(filepath.Join(deviceDir, name))
+		if err != nil {
+			continue
+		}
+		value := strings.TrimSpace(string(data))
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func readAMDSysfsTemperature(deviceDir string) uint64 {
+	hwmons, err := filepath.Glob(filepath.Join(deviceDir, "hwmon", "hwmon*"))
+	if err != nil {
+		return 0
+	}
+
+	var fallback uint64
+	for _, hwmon := range hwmons {
+		labels, _ := filepath.Glob(filepath.Join(hwmon, "temp*_label"))
+		for _, labelPath := range labels {
+			labelBytes, err := os.ReadFile(labelPath)
+			if err != nil {
+				continue
+			}
+			label := strings.ToLower(strings.TrimSpace(string(labelBytes)))
+			inputPath := strings.TrimSuffix(labelPath, "_label") + "_input"
+			milli, err := readSysfsUint(inputPath)
+			if err != nil {
+				continue
+			}
+			celsius := milli / 1000
+			if strings.Contains(label, "junction") || strings.Contains(label, "edge") {
+				return celsius
+			}
+			if fallback == 0 {
+				fallback = celsius
+			}
+		}
+
+		if fallback == 0 {
+			inputs, _ := filepath.Glob(filepath.Join(hwmon, "temp*_input"))
+			for _, inputPath := range inputs {
+				milli, err := readSysfsUint(inputPath)
+				if err != nil {
+					continue
+				}
+				fallback = milli / 1000
+				break
+			}
+		}
+	}
+	return fallback
+}
+
+func readSysfsUint(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+}
+
+func readSysfsFloat(path string) (float64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseFloat(strings.TrimSpace(string(data)), 64)
+}

--- a/monitoring/unit/gpu_amd_sysfs_linux_test.go
+++ b/monitoring/unit/gpu_amd_sysfs_linux_test.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package monitoring
+
+import "testing"
+
+func TestAMDSysfsDetailedInfo(t *testing.T) {
+	infos, err := getAMDSysfsDetailedInfo()
+	if err != nil {
+		t.Skipf("no amdgpu sysfs metrics on this host: %v", err)
+	}
+	if len(infos) == 0 {
+		t.Skip("no amdgpu sysfs metrics on this host")
+	}
+	for i, info := range infos {
+		t.Logf("gpu[%d] name=%s util=%.1f mem=%d/%d temp=%d", i, info.Name, info.Utilization, info.MemoryUsed, info.MemoryTotal, info.Temperature)
+		if info.Name == "" {
+			t.Errorf("gpu[%d] missing name", i)
+		}
+		if info.MemoryTotal == 0 {
+			t.Errorf("gpu[%d] missing vram total", i)
+		}
+	}
+}

--- a/monitoring/unit/gpu_detailed_linux.go
+++ b/monitoring/unit/gpu_detailed_linux.go
@@ -15,11 +15,11 @@ var vendorType = getDetailedVendor()
 
 // DetailedGPUInfo 详细GPU信息结构体
 type DetailedGPUInfo struct {
-	Name         string  `json:"name"`          // GPU型号
-	MemoryTotal  uint64  `json:"memory_total"`  // 总显存 (字节)
-	MemoryUsed   uint64  `json:"memory_used"`   // 已用显存 (字节)
-	Utilization  float64 `json:"utilization"`   // GPU使用率 (0-100)
-	Temperature  uint64  `json:"temperature"`   // 温度 (摄氏度)
+	Name        string  `json:"name"`         // GPU型号
+	MemoryTotal uint64  `json:"memory_total"` // 总显存 (字节)
+	MemoryUsed  uint64  `json:"memory_used"`  // 已用显存 (字节)
+	Utilization float64 `json:"utilization"`  // GPU使用率 (0-100)
+	Temperature uint64  `json:"temperature"`  // 温度 (摄氏度)
 }
 
 func getDetailedVendor() uint8 {
@@ -47,18 +47,10 @@ func getNvidiaDetailedStat() ([]float64, error) {
 }
 
 func getAMDDetailedStat() ([]float64, error) {
-	rsmi := &ROCmSMI{
-		BinPath: "/opt/rocm/bin/rocm-smi",
+	if data, err := getAMDROCmDetailedStat(); err == nil && len(data) > 0 {
+		return data, nil
 	}
-	err := rsmi.Start()
-	if err != nil {
-		return nil, err
-	}
-	data, err := rsmi.GatherUsage()
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return getAMDSysfsDetailedStat()
 }
 
 func getNvidiaDetailedHost() ([]string, error) {
@@ -77,18 +69,10 @@ func getNvidiaDetailedHost() ([]string, error) {
 }
 
 func getAMDDetailedHost() ([]string, error) {
-	rsmi := &ROCmSMI{
-		BinPath: "/opt/rocm/bin/rocm-smi",
+	if data, err := getAMDROCmDetailedHost(); err == nil && len(data) > 0 {
+		return data, nil
 	}
-	err := rsmi.Start()
-	if err != nil {
-		return nil, err
-	}
-	data, err := rsmi.GatherModel()
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return getAMDSysfsDetailedHost()
 }
 
 // GetDetailedGPUHost 获取GPU型号信息
@@ -162,52 +146,76 @@ func getNvidiaDetailedInfo() ([]DetailedGPUInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	data, err := smi.GatherDetailedInfo()
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var gpuInfos []DetailedGPUInfo
 	for _, nvidiaInfo := range data {
 		gpuInfo := DetailedGPUInfo{
-			Name:         nvidiaInfo.Name,
-			MemoryTotal:  nvidiaInfo.MemoryTotal,
-			MemoryUsed:   nvidiaInfo.MemoryUsed,
-			Utilization:  nvidiaInfo.Utilization,
-			Temperature:  nvidiaInfo.Temperature,
+			Name:        nvidiaInfo.Name,
+			MemoryTotal: nvidiaInfo.MemoryTotal,
+			MemoryUsed:  nvidiaInfo.MemoryUsed,
+			Utilization: nvidiaInfo.Utilization,
+			Temperature: nvidiaInfo.Temperature,
 		}
 		gpuInfos = append(gpuInfos, gpuInfo)
 	}
-	
+
 	return gpuInfos, nil
 }
 
 func getAMDDetailedInfo() ([]DetailedGPUInfo, error) {
+	if gpuInfos, err := getAMDROCmDetailedInfo(); err == nil && len(gpuInfos) > 0 {
+		return gpuInfos, nil
+	}
+	return getAMDSysfsDetailedInfo()
+}
+
+func getAMDROCmDetailedStat() ([]float64, error) {
 	rsmi := &ROCmSMI{
 		BinPath: "/opt/rocm/bin/rocm-smi",
 	}
-	err := rsmi.Start()
-	if err != nil {
+	if err := rsmi.Start(); err != nil {
 		return nil, err
 	}
-	
+	return rsmi.GatherUsage()
+}
+
+func getAMDROCmDetailedHost() ([]string, error) {
+	rsmi := &ROCmSMI{
+		BinPath: "/opt/rocm/bin/rocm-smi",
+	}
+	if err := rsmi.Start(); err != nil {
+		return nil, err
+	}
+	return rsmi.GatherModel()
+}
+
+func getAMDROCmDetailedInfo() ([]DetailedGPUInfo, error) {
+	rsmi := &ROCmSMI{
+		BinPath: "/opt/rocm/bin/rocm-smi",
+	}
+	if err := rsmi.Start(); err != nil {
+		return nil, err
+	}
+
 	data, err := rsmi.GatherDetailedInfo()
 	if err != nil {
 		return nil, err
 	}
-	
+
 	var gpuInfos []DetailedGPUInfo
 	for _, amdInfo := range data {
-		gpuInfo := DetailedGPUInfo{
-			Name:         amdInfo.Name,
-			MemoryTotal:  amdInfo.MemoryTotal,
-			MemoryUsed:   amdInfo.MemoryUsed,
-			Utilization:  amdInfo.Utilization,
-			Temperature:  amdInfo.Temperature,
-		}
-		gpuInfos = append(gpuInfos, gpuInfo)
+		gpuInfos = append(gpuInfos, DetailedGPUInfo{
+			Name:        amdInfo.Name,
+			MemoryTotal: amdInfo.MemoryTotal,
+			MemoryUsed:  amdInfo.MemoryUsed,
+			Utilization: amdInfo.Utilization,
+			Temperature: amdInfo.Temperature,
+		})
 	}
-	
 	return gpuInfos, nil
 }


### PR DESCRIPTION
## 问题

`--gpu` 在 Linux 上采集 AMD 占用依赖 `rocm-smi --showallinfo --json`。消费级 APU（Phoenix / Ryzen Z1 Extreme 等）上常见情况：

- 没有 `/opt/rocm/bin/rocm-smi`，只有发行版 `/usr/bin/rocm-smi`
- `rocm-smi` 能打出 JSON，但因 `sclk clock is unsupported` **exit code 2**
- 当前实现用 `CombinedOutput()`，非 0 退出码会丢掉整段输出
- 内核已经提供 `/sys/class/drm/card*/device/gpu_busy_percent`、VRAM、hwmon 温度

结果是面板能看到 GPU 名字，但占用一直为空。

## 改动

- `rocm-smi` 成功时行为不变
- 失败时回退读取 amdgpu sysfs：`gpu_busy_percent`、`mem_info_vram_*`、hwmon 温度
- 无 amdgpu 的 CI/机器上测试会 skip

## 测试

- 本机 Z1 Extreme / Phoenix1：`GetDetailedGPUInfo()` 返回占用、显存、温度
- `go test ./monitoring/unit`